### PR TITLE
Configured build to use JaCoCo to enforce minimum code coverage during all builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ script:
   - mvn clean install
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then mvn deploy -DskipTests -P release -s maven-settings.xml; fi
 
+after_success:
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then mvn jacoco:report coveralls:report; fi
+
 notifications:
   email:
     recipients:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Embedded RabbitMQ
 
 [![Build Status](https://travis-ci.org/AlejandroRivera/embedded-rabbitmq.svg?branch=master)](https://travis-ci.org/AlejandroRivera/embedded-rabbitmq)
+[![Coverage Status](https://coveralls.io/repos/github/AlejandroRivera/embedded-rabbitmq/badge.svg)](https://coveralls.io/github/AlejandroRivera/embedded-rabbitmq)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/io-arivera-oss/embedded-rabbitmq)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.arivera.oss/embedded-rabbitmq/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.arivera.oss/embedded-rabbitmq)
 

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
             <id>travis</id>
             <activation>
                 <property>
-                    <name>TRAVIS_OS_NAME</name>
+                    <name>env.TRAVIS_OS_NAME</name>
                     <value>linux</value>
                 </property>
             </activation>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
                                 <limit>
                                     <counter>BRANCH</counter>
                                     <value>COVEREDRATIO</value>
-                                    <minimum>0.34</minimum>
+                                    <minimum>0.30</minimum>
                                 </limit>
                             </limits>
                         </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
                                 <limit>
                                     <counter>BRANCH</counter>
                                     <value>COVEREDRATIO</value>
-                                    <maximum>0.34</maximum>
+                                    <minimum>0.34</minimum>
                                 </limit>
                             </limits>
                         </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
                                 <limit>
                                     <counter>INSTRUCTION</counter>
                                     <value>COVEREDRATIO</value>
-                                    <minimum>0.62</minimum>
+                                    <minimum>0.61</minimum>
                                 </limit>
                                 <limit>
                                     <counter>CLASS</counter>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,16 @@
                     </rules>
                 </configuration>
             </plugin>
+            <plugin>
+                <!-- Coveralls collects Code Coverage reports from Travis. -->
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>4.2.0</version>
+                <configuration>
+                    <repoToken>E5aoVZnhwn16IJJHVCb8aDA85JjCZT1c9</repoToken>
+                    <failOnServiceError>false</failOnServiceError>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -190,10 +190,6 @@
             <id>travis</id>
             <activation>
                 <property>
-                    <name>TRAVIS</name>
-                    <value>true</value>
-                </property>
-                <property>
                     <name>TRAVIS_OS_NAME</name>
                     <value>linux</value>
                 </property>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
         <developerConnection>scm:git:ssh://github.com/AlejandroRivera/embedded-rabbitmq.git</developerConnection>
     </scm>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <dependencies>
         <dependency>
             <!-- Logging Facade -->
@@ -112,6 +116,64 @@
                     <autoReleaseAfterClose>false</autoReleaseAfterClose>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <!-- Code Coverage tool -->
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.7.201606060606</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>verify</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <rules>
+                        <rule>
+                            <element>BUNDLE</element>
+                            <limits>
+                                <limit>
+                                    <counter>INSTRUCTION</counter>
+                                    <value>COVEREDRATIO</value>
+                                    <minimum>0.62</minimum>
+                                </limit>
+                                <limit>
+                                    <counter>CLASS</counter>
+                                    <value>MISSEDCOUNT</value>
+                                    <maximum>6</maximum>
+                                </limit>
+                                <limit>
+                                    <counter>BRANCH</counter>
+                                    <value>COVEREDRATIO</value>
+                                    <maximum>0.34</maximum>
+                                </limit>
+                            </limits>
+                        </rule>
+                        <rule>
+                            <element>CLASS</element>
+                            <excludes>
+                                <exclude>*Test</exclude>
+                            </excludes>
+                            <limits>
+                                <limit>
+                                    <counter>LINE</counter>
+                                    <value>COVEREDRATIO</value>
+                                    <minimum>0.00</minimum>
+                                </limit>
+                            </limits>
+                        </rule>
+                    </rules>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -123,6 +185,70 @@
     </distributionManagement>
 
     <profiles>
+        <profile>
+            <!--This profile is to be used only when building from Travis CI and only when using the Linux build (not OS X!)-->
+            <id>travis</id>
+            <activation>
+                <property>
+                    <name>TRAVIS</name>
+                    <value>true</value>
+                </property>
+                <property>
+                    <name>TRAVIS_OS_NAME</name>
+                    <value>linux</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!--
+                        When building in Travis, we need to generate the JaCoCo Report before uploading results to Coveralls.
+                        This build plugin needs to be listed BEFORE the build plugin for Coveralls. XML declaration order matters!
+                        -->
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.7.7.201606060606</version>
+                        <executions>
+                            <execution>
+                                <id>report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <!--
+                                By binding to 'verify' we ensure this is done within the scope of a 'mvn install',
+                                instead of the default of 'mvn site/deploy'
+                                -->
+                                <phase>verify</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <!-- Coveralls collects Code Coverage reports from Travis. -->
+                        <groupId>org.eluder.coveralls</groupId>
+                        <artifactId>coveralls-maven-plugin</artifactId>
+                        <version>4.2.0</version>
+                        <configuration>
+                            <repoToken>E5aoVZnhwn16IJJHVCb8aDA85JjCZT1c9</repoToken>
+                            <failOnServiceError>false</failOnServiceError>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <!--
+                                We want to upload the report during a normal 'mvn install', hence we bind to 'verify',
+                                but we won't break the build if the upload fails due to 'failOnServiceError=false'
+                                -->
+                                <phase>verify</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <id>release</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -186,66 +186,6 @@
 
     <profiles>
         <profile>
-            <!--This profile is to be used only when building from Travis CI and only when using the Linux build (not OS X!)-->
-            <id>travis</id>
-            <activation>
-                <property>
-                    <name>env.TRAVIS_OS_NAME</name>
-                    <value>linux</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!--
-                        When building in Travis, we need to generate the JaCoCo Report before uploading results to Coveralls.
-                        This build plugin needs to be listed BEFORE the build plugin for Coveralls. XML declaration order matters!
-                        -->
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.7.7.201606060606</version>
-                        <executions>
-                            <execution>
-                                <id>report</id>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                                <!--
-                                By binding to 'verify' we ensure this is done within the scope of a 'mvn install',
-                                instead of the default of 'mvn site/deploy'
-                                -->
-                                <phase>verify</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <!-- Coveralls collects Code Coverage reports from Travis. -->
-                        <groupId>org.eluder.coveralls</groupId>
-                        <artifactId>coveralls-maven-plugin</artifactId>
-                        <version>4.2.0</version>
-                        <configuration>
-                            <repoToken>E5aoVZnhwn16IJJHVCb8aDA85JjCZT1c9</repoToken>
-                            <failOnServiceError>false</failOnServiceError>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>report</id>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                                <!--
-                                We want to upload the report during a normal 'mvn install', hence we bind to 'verify',
-                                but we won't break the build if the upload fails due to 'failOnServiceError=false'
-                                -->
-                                <phase>verify</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
             <id>release</id>
             <build>
                 <plugins>

--- a/src/test/java/io/arivera/oss/embedded/rabbitmq/EmbeddedRabbitMqTest.java
+++ b/src/test/java/io/arivera/oss/embedded/rabbitmq/EmbeddedRabbitMqTest.java
@@ -11,6 +11,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.TimeUnit;
+
 public class EmbeddedRabbitMqTest {
 
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(EmbeddedRabbitMqTest.class);
@@ -27,6 +29,7 @@ public class EmbeddedRabbitMqTest {
 //            new URL("https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_5/rabbitmq-server-generic-unix-3.6.5.tar.xz"), "3.6.5")
         .version(PredefinedVersion.V3_5_7)
         .extractionFolder(temporaryFolder.newFolder("extracted"))
+        .rabbitMqServerInitializationTimeoutInMillis(TimeUnit.SECONDS.toMillis(5))
 //        .useCachedDownload(false)
         .build();
 


### PR DESCRIPTION
Coveralls will be used to publish coverage while building in Travis CI.

TODO: Coverage rules still need tweaking.