### PR TITLE
RabbitMq can now be started using a random port

### DIFF
--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/EmbeddedRabbitMqConfig.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/EmbeddedRabbitMqConfig.java
@@ -6,6 +6,7 @@ import io.arivera.oss.embedded.rabbitmq.bin.RabbitMqCtl;
 import io.arivera.oss.embedded.rabbitmq.bin.RabbitMqPlugins;
 import io.arivera.oss.embedded.rabbitmq.bin.RabbitMqServer;
 import io.arivera.oss.embedded.rabbitmq.util.OperatingSystem;
+import io.arivera.oss.embedded.rabbitmq.util.RandomPortSupplier;
 
 import java.io.File;
 import java.net.URL;
@@ -125,6 +126,20 @@ public class EmbeddedRabbitMqConfig {
 
   public Version getVersion() {
     return version;
+  }
+
+  /**
+   * Returns the RabbitMQ node port as defined by the {@link #envVars} or the default port if not defined.
+   * <p>
+   * This method will return the correct port even if the {@link Builder#randomPort()} method was used.
+   */
+  public int getRabbitMqPort() {
+    String portValue = this.envVars.get(RabbitMqEnvVar.NODE_PORT.getEnvVarName());
+    if (portValue == null) {
+      return RabbitMqEnvVar.DEFAULT_NODE_PORT;
+    } else {
+      return Integer.parseInt(portValue);
+    }
   }
 
   /**
@@ -336,6 +351,32 @@ public class EmbeddedRabbitMqConfig {
     public Builder envVar(RabbitMqEnvVar key, String value) {
       this.envVar(key.getEnvVarName(), value);
       return this;
+    }
+
+    /**
+     * Defines the port that this RabbitMQ broker node will run on.
+     * <p>
+     * The port is defined by setting the environment variable {@link RabbitMqEnvVar#NODE_PORT}
+     *
+     * @param port any valid port number or {@code -1} to use any random available port (same as {@link #randomPort()})
+     */
+    public Builder port(int port) {
+      if (port == -1) {
+        return this.randomPort();
+      } else {
+        this.envVar(RabbitMqEnvVar.NODE_PORT, String.valueOf(port));
+        return this;
+      }
+    }
+
+    /**
+     * Defines the port that this RabbitMQ broker node will run on.
+     * <p>
+     * The port is defined by setting the environment variable {@link RabbitMqEnvVar#NODE_PORT}
+     */
+    public Builder randomPort() {
+      int randomPort = new RandomPortSupplier().get();
+      return port(randomPort);
     }
 
     /**

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/EmbeddedRabbitMqConfig.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/EmbeddedRabbitMqConfig.java
@@ -42,6 +42,7 @@ public class EmbeddedRabbitMqConfig {
   private final long downloadConnectionTimeoutInMillis;
   private final long defaultRabbitMqCtlTimeoutInMillis;
   private final long rabbitMqServerInitializationTimeoutInMillis;
+  private final long erlangCheckTimeoutInMillis;
 
   private final boolean shouldCacheDownload;
   private final boolean deleteCachedFileOnErrors;
@@ -58,6 +59,7 @@ public class EmbeddedRabbitMqConfig {
                                    long downloadConnectionTimeoutInMillis,
                                    long defaultRabbitMqCtlTimeoutInMillis,
                                    long rabbitMqServerInitializationTimeoutInMillis,
+                                   long erlangCheckTimeoutInMillis,
                                    boolean cacheDownload, boolean deleteCachedFile,
                                    Map<String, String> envVars,
                                    RabbitMqCommand.ProcessExecutorFactory processExecutorFactory) {
@@ -70,6 +72,7 @@ public class EmbeddedRabbitMqConfig {
     this.downloadConnectionTimeoutInMillis = downloadConnectionTimeoutInMillis;
     this.defaultRabbitMqCtlTimeoutInMillis = defaultRabbitMqCtlTimeoutInMillis;
     this.rabbitMqServerInitializationTimeoutInMillis = rabbitMqServerInitializationTimeoutInMillis;
+    this.erlangCheckTimeoutInMillis = erlangCheckTimeoutInMillis;
     this.shouldCacheDownload = cacheDownload;
     this.deleteCachedFileOnErrors = deleteCachedFile;
     this.envVars = envVars;
@@ -90,6 +93,10 @@ public class EmbeddedRabbitMqConfig {
 
   public long getRabbitMqServerInitializationTimeoutInMillis() {
     return rabbitMqServerInitializationTimeoutInMillis;
+  }
+
+  public long getErlangCheckTimeoutInMillis() {
+    return erlangCheckTimeoutInMillis;
   }
 
   public URL getDownloadSource() {
@@ -165,6 +172,7 @@ public class EmbeddedRabbitMqConfig {
     private long downloadConnectionTimeoutInMillis;
     private long defaultRabbitMqCtlTimeoutInMillis;
     private long rabbitMqServerInitializationTimeoutInMillis;
+    private long erlangCheckTimeoutInMillis;
     private File downloadFolder;
     private File downloadTarget;
     private File extractionFolder;
@@ -185,6 +193,7 @@ public class EmbeddedRabbitMqConfig {
       this.downloadReadTimeoutInMillis = TimeUnit.SECONDS.toMillis(3);
       this.defaultRabbitMqCtlTimeoutInMillis = TimeUnit.SECONDS.toMillis(2);
       this.rabbitMqServerInitializationTimeoutInMillis = TimeUnit.SECONDS.toMillis(3);
+      this.erlangCheckTimeoutInMillis = TimeUnit.SECONDS.toMillis(1);
       this.cacheDownload = true;
       this.deleteCachedFile = true;
       this.downloadFolder = new File(System.getProperty("user.home"), DOWNLOAD_FOLDER);
@@ -214,6 +223,12 @@ public class EmbeddedRabbitMqConfig {
     @Beta
     public Builder rabbitMqServerInitializationTimeoutInMillis(long rabbitMqServerInitializationTimeoutInMillis) {
       this.rabbitMqServerInitializationTimeoutInMillis = rabbitMqServerInitializationTimeoutInMillis;
+      return this;
+    }
+
+    @Beta
+    public Builder erlangCheckTimeoutInMillis(long erlangCheckTimeoutInMillis) {
+      this.erlangCheckTimeoutInMillis = erlangCheckTimeoutInMillis;
       return this;
     }
 
@@ -428,6 +443,7 @@ public class EmbeddedRabbitMqConfig {
           downloadConnectionTimeoutInMillis, downloadReadTimeoutInMillis,
           defaultRabbitMqCtlTimeoutInMillis,
           rabbitMqServerInitializationTimeoutInMillis,
+          erlangCheckTimeoutInMillis,
           cacheDownload, deleteCachedFile,
           envVars,
           processExecutorFactory);

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/RabbitMqEnvVar.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/RabbitMqEnvVar.java
@@ -18,7 +18,7 @@ public enum RabbitMqEnvVar {
   /**
    * The port to bind this RabbitMQ broker node.
    *
-   * <p>Default value: {@code 5672}</p>
+   * <p>Default value: {@value DEFAULT_NODE_PORT}</p>
    */
   NODE_PORT,
 
@@ -132,6 +132,8 @@ public enum RabbitMqEnvVar {
   CONFIG_FILE;
 
   private static final String ENV_VAR_PREFIX = "RABBITMQ_";
+
+  public static final int DEFAULT_NODE_PORT = 5672;
 
   RabbitMqEnvVar() {
   }

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/RabbitMqEnvVar.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/RabbitMqEnvVar.java
@@ -131,9 +131,9 @@ public enum RabbitMqEnvVar {
    */
   CONFIG_FILE;
 
-  private static final String ENV_VAR_PREFIX = "RABBITMQ_";
-
   public static final int DEFAULT_NODE_PORT = 5672;
+
+  private static final String ENV_VAR_PREFIX = "RABBITMQ_";
 
   RabbitMqEnvVar() {
   }

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/bin/ErlangShell.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/bin/ErlangShell.java
@@ -21,13 +21,14 @@ public class ErlangShell {
 
   private static final String UNIX_ERL_COMMAND = "erl";
 
-  private final RabbitMqCommand.ProcessExecutorFactory processExecutorFactory;
+  private final EmbeddedRabbitMqConfig config;
 
   /**
    * Generic Constructor.
    */
   public ErlangShell(final EmbeddedRabbitMqConfig config) {
-    this.processExecutorFactory = config.getProcessExecutorFactory();
+    this.config = config;
+
   }
 
   /**
@@ -42,10 +43,9 @@ public class ErlangShell {
 
     Slf4jStream stream = Slf4jStream.of(processOutputLogger);
 
-    final ProcessExecutor processExecutor = processExecutorFactory.createInstance()
-        .command(erlangShell,
-            "-noshell", "-eval", "erlang:display(erlang:system_info(otp_release)), halt().")
-        .timeout(1L, TimeUnit.SECONDS)
+    final ProcessExecutor processExecutor = config.getProcessExecutorFactory().createInstance()
+        .command(erlangShell, "-noshell", "-eval", "erlang:display(erlang:system_info(otp_release)), halt().")
+        .timeout(config.getErlangCheckTimeoutInMillis(), TimeUnit.MILLISECONDS)
         .redirectError(stream.as(Level.WARN))
         .destroyOnExit()
         .readOutput(true);

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/util/RandomPortSupplier.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/util/RandomPortSupplier.java
@@ -1,10 +1,15 @@
 package io.arivera.oss.embedded.rabbitmq.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.ServerSocket;
 import javax.net.ServerSocketFactory;
 
 public class RandomPortSupplier {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RandomPortSupplier.class);
 
   private final ServerSocketFactory severSocketFactory;
 
@@ -34,7 +39,7 @@ public class RandomPortSupplier {
         try {
           socket.close();
         } catch (IOException e) {
-          // swallow exception
+          LOGGER.debug("Couldn't close socket that was temporarily opened to determine random port.", e);
         }
       }
     }

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/util/RandomPortSupplier.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/util/RandomPortSupplier.java
@@ -1,8 +1,8 @@
 package io.arivera.oss.embedded.rabbitmq.util;
 
-import javax.net.ServerSocketFactory;
 import java.io.IOException;
 import java.net.ServerSocket;
+import javax.net.ServerSocketFactory;
 
 public class RandomPortSupplier {
 
@@ -19,7 +19,7 @@ public class RandomPortSupplier {
   /**
    * @return an available port assigned at random by the OS.
    *
-   * @throws IllegalStateException
+   * @throws IllegalStateException if the port cannot be determined.
    */
   public int get() throws IllegalStateException {
     ServerSocket socket = null;

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/util/RandomPortSupplier.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/util/RandomPortSupplier.java
@@ -1,0 +1,42 @@
+package io.arivera.oss.embedded.rabbitmq.util;
+
+import javax.net.ServerSocketFactory;
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public class RandomPortSupplier {
+
+  private final ServerSocketFactory severSocketFactory;
+
+  public RandomPortSupplier() {
+    this(ServerSocketFactory.getDefault());
+  }
+
+  public RandomPortSupplier(ServerSocketFactory severSocketFactory) {
+    this.severSocketFactory = severSocketFactory;
+  }
+
+  /**
+   * @return an available port assigned at random by the OS.
+   *
+   * @throws IllegalStateException
+   */
+  public int get() throws IllegalStateException {
+    ServerSocket socket = null;
+    try {
+      socket = this.severSocketFactory.createServerSocket(0);
+      socket.setReuseAddress(false);
+      return socket.getLocalPort();
+    } catch (IOException e) {
+      throw new IllegalStateException("Could not determine random port to assign.", e);
+    } finally {
+      if (socket != null) {
+        try {
+          socket.close();
+        } catch (IOException e) {
+          // swallow exception
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
+++ b/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
@@ -37,7 +37,6 @@ import static org.hamcrest.core.Is.is;
 public class EmbeddedRabbitMqTest {
 
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(EmbeddedRabbitMqTest.class);
-  public static final int PORT = 5673;
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -47,13 +46,14 @@ public class EmbeddedRabbitMqTest {
   public void start() throws Exception {
     File configFile = temporaryFolder.newFile("rabbitmq.config");
     FileOutputStream fileOutputStream = new FileOutputStream(configFile);
-    fileOutputStream.write(String.format("[{rabbit, [{tcp_listeners, [%d]}]}].", PORT).getBytes("utf-8"));
+    fileOutputStream.write("[{rabbit,[{log_levels,[{connection,debug},{channel,debug}]}]}].".getBytes("utf-8"));
     fileOutputStream.close();
 
     EmbeddedRabbitMqConfig config = new EmbeddedRabbitMqConfig.Builder()
         .version(PredefinedVersion.V3_5_7)
-          .downloadFrom(OfficialArtifactRepository.RABBITMQ)
-  //        .downloadFrom(new URL("https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_6_milestone1/rabbitmq-server-mac-standalone-3.6.5.901.tar.xz"), "rabbitmq_server-3.6.5.901")
+        .randomPort()
+        .downloadFrom(OfficialArtifactRepository.RABBITMQ)
+//        .downloadFrom(new URL("https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_6_milestone1/rabbitmq-server-mac-standalone-3.6.5.901.tar.xz"), "rabbitmq_server-3.6.5.901")
 //        .envVar(RabbitMqEnvVar.NODE_PORT, String.valueOf(PORT))
         .envVar(RabbitMqEnvVar.CONFIG_FILE, configFile.toString().replace(".config", ""))
         .extractionFolder(temporaryFolder.newFolder("extracted"))
@@ -68,7 +68,7 @@ public class EmbeddedRabbitMqTest {
 
     ConnectionFactory connectionFactory = new ConnectionFactory();
     connectionFactory.setHost("localhost");
-    connectionFactory.setPort(PORT);
+    connectionFactory.setPort(config.getRabbitMqPort());
     connectionFactory.setVirtualHost("/");
     connectionFactory.setUsername("guest");
     connectionFactory.setPassword("guest");

--- a/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
+++ b/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
@@ -57,9 +57,9 @@ public class EmbeddedRabbitMqTest {
 //        .envVar(RabbitMqEnvVar.NODE_PORT, String.valueOf(PORT))
         .envVar(RabbitMqEnvVar.CONFIG_FILE, configFile.toString().replace(".config", ""))
         .extractionFolder(temporaryFolder.newFolder("extracted"))
-        .rabbitMqServerInitializationTimeoutInMillis(TimeUnit.SECONDS.toMillis(10))
-        .defaultRabbitMqCtlTimeoutInMillis(TimeUnit.SECONDS.toMillis(10))
-        .erlangCheckTimeoutInMillis(TimeUnit.SECONDS.toMillis(4))
+        .rabbitMqServerInitializationTimeoutInMillis(TimeUnit.SECONDS.toMillis(20))
+        .defaultRabbitMqCtlTimeoutInMillis(TimeUnit.SECONDS.toMillis(20))
+        .erlangCheckTimeoutInMillis(TimeUnit.SECONDS.toMillis(10))
 //        .useCachedDownload(false)
         .build();
 

--- a/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
+++ b/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
@@ -59,7 +59,7 @@ public class EmbeddedRabbitMqTest {
         .extractionFolder(temporaryFolder.newFolder("extracted"))
         .rabbitMqServerInitializationTimeoutInMillis(TimeUnit.SECONDS.toMillis(10))
         .defaultRabbitMqCtlTimeoutInMillis(TimeUnit.SECONDS.toMillis(10))
-        .erlangCheckTimeoutInMillis(TimeUnit.SECONDS.toMillis(3))
+        .erlangCheckTimeoutInMillis(TimeUnit.SECONDS.toMillis(4))
 //        .useCachedDownload(false)
         .build();
 

--- a/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
+++ b/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
@@ -59,6 +59,7 @@ public class EmbeddedRabbitMqTest {
         .extractionFolder(temporaryFolder.newFolder("extracted"))
         .rabbitMqServerInitializationTimeoutInMillis(TimeUnit.SECONDS.toMillis(10))
         .defaultRabbitMqCtlTimeoutInMillis(TimeUnit.SECONDS.toMillis(10))
+        .erlangCheckTimeoutInMillis(TimeUnit.SECONDS.toMillis(3))
 //        .useCachedDownload(false)
         .build();
 

--- a/src/test/java/io/arivera/oss/embedded/rabbitmq/bin/ErlangShellTest.java
+++ b/src/test/java/io/arivera/oss/embedded/rabbitmq/bin/ErlangShellTest.java
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -29,6 +30,7 @@ public class ErlangShellTest {
   public void setUp() throws Exception {
     configBuilder = new EmbeddedRabbitMqConfig.Builder()
       .envVars(new HashMap<String, String>())
+      .erlangCheckTimeoutInMillis(TimeUnit.SECONDS.toMillis(3))
       .extractionFolder(tempFolder.getRoot())
       .version(this.version)
       .processExecutorFactory(this.factory);

--- a/src/test/java/io/arivera/oss/embedded/rabbitmq/bin/ErlangShellTest.java
+++ b/src/test/java/io/arivera/oss/embedded/rabbitmq/bin/ErlangShellTest.java
@@ -30,7 +30,7 @@ public class ErlangShellTest {
   public void setUp() throws Exception {
     configBuilder = new EmbeddedRabbitMqConfig.Builder()
       .envVars(new HashMap<String, String>())
-      .erlangCheckTimeoutInMillis(TimeUnit.SECONDS.toMillis(3))
+      .erlangCheckTimeoutInMillis(TimeUnit.SECONDS.toMillis(4))
       .extractionFolder(tempFolder.getRoot())
       .version(this.version)
       .processExecutorFactory(this.factory);

--- a/src/test/java/io/arivera/oss/embedded/rabbitmq/util/RandomPortSupplierTest.java
+++ b/src/test/java/io/arivera/oss/embedded/rabbitmq/util/RandomPortSupplierTest.java
@@ -1,0 +1,41 @@
+package io.arivera.oss.embedded.rabbitmq.util;
+
+import org.junit.Test;
+
+import javax.net.ServerSocketFactory;
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RandomPortSupplierTest {
+
+  @Test
+  public void testRandomPortIsReturned() throws IOException {
+    int port = new RandomPortSupplier().get();
+    assertThat(port, not(equalTo(0)));
+  }
+
+  @Test
+  public void testPortIsAvailable() throws IOException {
+    int port = new RandomPortSupplier().get();
+    ServerSocket serverSocket = new ServerSocket(port);
+    assertThat(serverSocket, notNullValue());
+    serverSocket.close();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testPortCantBeAssigned() throws IOException {
+    ServerSocketFactory factory = mock(ServerSocketFactory.class);
+    when(factory.createServerSocket(anyInt()))
+        .thenThrow(new IOException("Fake"));
+    new RandomPortSupplier(factory).get();
+
+  }
+}


### PR DESCRIPTION
`EmbeddedRabbitMqConfig.Builder()` now has two new methods:
```
  builder.port(portNumber)
```
and
```
  builder.randomPort()     // same as builder.port(-1)
```

The port number can be retrieved from the config itself:
```
    EmbeddedRabbitMqConfig config =  new EmbeddedRabbitMqConfig.Builder()
        .randomPort()
        .build();

    ConnectionFactory connectionFactory = new ConnectionFactory();
    connectionFactory.setPort(config.getRabbitMqPort()); 
    ...
```
