### PR TITLE
Moving Linux build to Circle CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: java
 
 matrix:
   include:
-  - os: linux         # Ubuntu 12.04 Precise
-    jdk: oraclejdk7   # Java 1.7.0_76
   - os: osx           # OS X (10.9) which comes with Oracle's Java 1.7.0_45
 
 env:
@@ -18,16 +16,16 @@ cache:
     - $HOME/.embeddedrabbitmq
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install erlang; fi      # Erlang 17 will be installed without even updating brew!
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export JAVA_HOME="$(/usr/libexec/java_home -v 1.7)"; fi    # Required by Maven
+  - brew install erlang      # Erlang 17 will be installed without even updating brew!
+  - export JAVA_HOME="$(/usr/libexec/java_home -v 1.7)"    # Required by Maven
   - erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
 
 script:
   - mvn clean install
 
 after_success:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then mvn deploy -DskipTests -s maven-settings.xml; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then mvn jacoco:report coveralls:report; fi
+  - mvn deploy -DskipTests -s maven-settings.xml
+  - mvn jacoco:report coveralls:report
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [![OS X](https://img.shields.io/badge/platform-os%20x-brightgreen.svg)]()
 [![Windows](https://img.shields.io/badge/platform-windows-brightgreen.svg)]()
 <br/>
-<sup>**Builds**: Linux/OS X</sup> 
+<sup>**Builds**: Linux</sup>
+[![CircleCI](https://circleci.com/gh/AlejandroRivera/embedded-rabbitmq/tree/master.svg?style=svg)](https://circleci.com/gh/AlejandroRivera/embedded-rabbitmq/tree/master)
+<sup>OS X</sup> 
 [![Build Status](https://travis-ci.org/AlejandroRivera/embedded-rabbitmq.svg?branch=master)](https://travis-ci.org/AlejandroRivera/embedded-rabbitmq)
 <sup>Windows</sup> 
 [![Build status](https://ci.appveyor.com/api/projects/status/r46o01l4ora7ppkf/branch/master?svg=true)](https://ci.appveyor.com/project/AlejandroRivera/embedded-rabbitmq)

--- a/circle.yml
+++ b/circle.yml
@@ -8,3 +8,7 @@ test:
   override:
     - erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
     - mvn clean install
+
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,10 @@
+## Customize the test machine
+machine:
+  cache_directories:
+    - "~/.m2/repository"
+    - "~/.embeddedrabbitmq"
+
+test:
+  override:
+    - erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
+    - mvn clean install

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,5 @@
 ## Customize the test machine
-machine:
+dependencies:
   cache_directories:
     - "~/.m2/repository"
     - "~/.embeddedrabbitmq"


### PR DESCRIPTION
After Travi's latest update, builds are now extremely slow in Linux due to slow process execution of RabbitMQ.

See failed builds:
* https://travis-ci.org/AlejandroRivera/embedded-rabbitmq/jobs/178038222#L542
* https://travis-ci.org/AlejandroRivera/embedded-rabbitmq/jobs/178003577#L542