### PR TITLE
Default proxy value should be null instead of `Proxy.NO_PROXY`.

### DIFF
--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/EmbeddedRabbitMqConfig.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/EmbeddedRabbitMqConfig.java
@@ -191,7 +191,7 @@ public class EmbeddedRabbitMqConfig {
     private Map<String, String> envVars;
     private ArtifactRepository artifactRepository;
     private RabbitMqCommand.ProcessExecutorFactory processExecutorFactory;
-    private Proxy downloadProxy = Proxy.NO_PROXY;
+    private Proxy downloadProxy = null;
 
     /**
      * Creates a new instance of the Configuration Builder.

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/apache/commons/io/FileUtils.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/apache/commons/io/FileUtils.java
@@ -75,7 +75,7 @@ public class FileUtils {
    */
   public static void copyURLToFile(URL source, File destination,
                                    int connectionTimeout, int readTimeout) throws IOException {
-    copyUrlToFile(source, destination, connectionTimeout, readTimeout, Proxy.NO_PROXY);
+    copyUrlToFile(source, destination, connectionTimeout, readTimeout, null);
   }
 
   /**

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/apache/commons/io/FileUtils.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/apache/commons/io/FileUtils.java
@@ -100,7 +100,12 @@ public class FileUtils {
    */
   public static void copyUrlToFile(URL source, File destination,
                                   int connectionTimeout, int readTimeout, Proxy proxy) throws IOException {
-    URLConnection connection = source.openConnection(proxy);
+    URLConnection connection;
+    if (proxy == null) {
+      connection = source.openConnection();
+    } else {
+      connection = source.openConnection(proxy);
+    }
     connection.setConnectTimeout(connectionTimeout);
     connection.setReadTimeout(readTimeout);
     InputStream input = connection.getInputStream();


### PR DESCRIPTION
Apparently, with a null proxy, global System properties can still be used;
but with `Proxy.NO_PROXY` that option goes away.

More info on: https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html

See Issue #39 for more details