### PR TITLE
Add support for RabbitMQ versions up to 3.7.7

### DIFF
--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/CustomVersion.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/CustomVersion.java
@@ -3,6 +3,8 @@ package io.arivera.oss.embedded.rabbitmq;
 import io.arivera.oss.embedded.rabbitmq.util.ArchiveType;
 import io.arivera.oss.embedded.rabbitmq.util.OperatingSystem;
 
+import java.util.List;
+
 /**
  * Class used when user wants to define a custom RabbitMQ version and/or download source.
  *
@@ -23,6 +25,11 @@ class CustomVersion implements Version {
   }
 
   @Override
+  public String getVersionAsString(CharSequence separator) {
+    throw new RuntimeException("This value isn't needed for custom downloads.");
+  }
+
+  @Override
   public ArchiveType getArchiveType(OperatingSystem operatingSystem) {
     throw new RuntimeException("This value isn't needed for custom downloads.");
   }
@@ -39,4 +46,10 @@ class CustomVersion implements Version {
   public String getMinimumErlangVersion() {
     return null;
   }
+
+  @Override
+  public List<Integer> getVersionComponents() {
+    throw new RuntimeException("This isn't needed for custom downloads.");
+  }
+
 }

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/EmbeddedRabbitMqConfig.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/EmbeddedRabbitMqConfig.java
@@ -207,7 +207,7 @@ public class EmbeddedRabbitMqConfig {
       this.cacheDownload = true;
       this.deleteCachedFile = true;
       this.downloadFolder = new File(System.getProperty("user.home"), DOWNLOAD_FOLDER);
-      this.artifactRepository = OfficialArtifactRepository.RABBITMQ;
+			this.artifactRepository = OfficialArtifactRepository.GITHUB;
       this.envVars = new HashMap<>();
       this.processExecutorFactory = new RabbitMqCommand.ProcessExecutorFactory();
     }
@@ -434,7 +434,7 @@ public class EmbeddedRabbitMqConfig {
      */
     public EmbeddedRabbitMqConfig build() {
       if (artifactRepository == null) {
-        artifactRepository = OfficialArtifactRepository.RABBITMQ;
+        artifactRepository = OfficialArtifactRepository.GITHUB;
       }
 
       OperatingSystem os = OperatingSystem.detect();

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/EmbeddedRabbitMqConfig.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/EmbeddedRabbitMqConfig.java
@@ -207,7 +207,7 @@ public class EmbeddedRabbitMqConfig {
       this.cacheDownload = true;
       this.deleteCachedFile = true;
       this.downloadFolder = new File(System.getProperty("user.home"), DOWNLOAD_FOLDER);
-			this.artifactRepository = OfficialArtifactRepository.GITHUB;
+      this.artifactRepository = OfficialArtifactRepository.GITHUB;
       this.envVars = new HashMap<>();
       this.processExecutorFactory = new RabbitMqCommand.ProcessExecutorFactory();
     }

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepository.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepository.java
@@ -15,6 +15,10 @@ import java.util.Map;
  */
 public enum OfficialArtifactRepository implements ArtifactRepository {
 
+  /**
+   * @deprecated in favor of {@link #GITHUB}. More info: <a href="http://www.rabbitmq.com/blog/2018/02/05/whats-new-in-rabbitmq-3-7/">Package Distribution Changes</a>
+   */
+  @Deprecated
   RABBITMQ("http://www.rabbitmq.com/releases/rabbitmq-server/%sv%s/rabbitmq-server-%s-%s.%s", VersionSupport.BELOW),
   GITHUB("https://github.com/rabbitmq/rabbitmq-server/releases/download/%sv%s/rabbitmq-server-%s-%s.%s", VersionSupport.ANY),
   BINTRAY("https://dl.bintray.com/rabbitmq/all/rabbitmq-server/%s%s/rabbitmq-server-%s-%s.%s", VersionSupport.ANY),

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepository.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepository.java
@@ -20,7 +20,7 @@ public enum OfficialArtifactRepository implements ArtifactRepository {
   BINTRAY("https://dl.bintray.com/rabbitmq/all/rabbitmq-server/%s%s/rabbitmq-server-%s-%s.%s", VersionSupport.ANY),
   ;
 
-  private static enum VersionSupport {
+  private enum VersionSupport {
     BELOW,
     ANY,
     ;

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepository.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepository.java
@@ -15,8 +15,8 @@ import java.util.Map;
  */
 public enum OfficialArtifactRepository implements ArtifactRepository {
 
-  GITHUB("https://github.com/rabbitmq/rabbitmq-server/releases/download/%sv%s/rabbitmq-server-%s-%s.%s", VersionSupport.ANY),
   RABBITMQ("http://www.rabbitmq.com/releases/rabbitmq-server/%sv%s/rabbitmq-server-%s-%s.%s", VersionSupport.BELOW),
+  GITHUB("https://github.com/rabbitmq/rabbitmq-server/releases/download/%sv%s/rabbitmq-server-%s-%s.%s", VersionSupport.ANY),
   BINTRAY("https://dl.bintray.com/rabbitmq/all/rabbitmq-server/%s%s/rabbitmq-server-%s-%s.%s", VersionSupport.ANY),
   ;
 

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/PredefinedVersion.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/PredefinedVersion.java
@@ -2,6 +2,10 @@ package io.arivera.oss.embedded.rabbitmq;
 
 import io.arivera.oss.embedded.rabbitmq.util.ArchiveType;
 import io.arivera.oss.embedded.rabbitmq.util.OperatingSystem;
+import io.arivera.oss.embedded.rabbitmq.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A list of RabbitMQ versions pre-configured to match the binaries distributed officially by RabbitMQ.
@@ -68,29 +72,44 @@ public enum PredefinedVersion implements Version {
 
   private static final String EXTRACTION_FOLDER = "rabbitmq_server-%s";
 
-  final String version;
+  final List<Integer> versionComponents;
   final ArchiveType unixArchiveType;
   final ArchiveType windowsArchiveType;
   final String minErlangVersion;
 
   PredefinedVersion(ArchiveType unixArchiveType, ArchiveType windowsArchiveType, String minErlangVersion) {
-    this.version = name().replaceAll("V", "").replaceAll("_", ".");
+    String[] versionComponents = name().replaceAll("V", "").split("_");
+    this.versionComponents = new ArrayList<>(versionComponents.length);
+    for (int i = 0; i < versionComponents.length; i++) {
+      this.versionComponents.add(Integer.parseInt(versionComponents[i]));
+    }
     this.unixArchiveType = unixArchiveType;
     this.windowsArchiveType = windowsArchiveType;
     this.minErlangVersion = minErlangVersion;
   }
 
   PredefinedVersion(PredefinedVersion version) {
-    this.version = version.getVersionAsString();
+    this.versionComponents =  version.getVersionComponents();
     this.unixArchiveType = version.getArchiveType(OperatingSystem.UNIX);
     this.windowsArchiveType = version.getArchiveType(OperatingSystem.WINDOWS);
     this.minErlangVersion = version.getMinimumErlangVersion();
   }
 
   @Override
-  public String getVersionAsString() {
-    return version;
+  public List<Integer> getVersionComponents() {
+    return versionComponents;
   }
+
+  @Override
+  public String getVersionAsString() {
+    return getVersionAsString(".");
+  }
+
+  @Override
+  public String getVersionAsString(CharSequence separator) {
+    return StringUtils.join(versionComponents, separator);
+  }
+
 
   @Override
   public ArchiveType getArchiveType(OperatingSystem operatingSystem) {

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/PredefinedVersion.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/PredefinedVersion.java
@@ -13,6 +13,22 @@ import io.arivera.oss.embedded.rabbitmq.util.OperatingSystem;
  */
 public enum PredefinedVersion implements Version {
 
+  V3_7_7(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_7_7_MIN_ERLANG_VERSION),
+  V3_7_6(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_7_X_MIN_ERLANG_VERSION),
+  V3_7_5(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_7_X_MIN_ERLANG_VERSION),
+  V3_7_4(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_7_X_MIN_ERLANG_VERSION),
+  V3_7_3(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_7_X_MIN_ERLANG_VERSION),
+  V3_7_2(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_7_X_MIN_ERLANG_VERSION),
+  V3_7_1(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_7_X_MIN_ERLANG_VERSION),
+  V3_7_0(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_7_X_MIN_ERLANG_VERSION),
+
+  V3_6_16(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_6_15_MIN_ERLANG_VERSION),
+  V3_6_15(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_6_15_MIN_ERLANG_VERSION),
+  V3_6_14(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_6_X_MIN_ERLANG_VERSION),
+  V3_6_13(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_6_X_MIN_ERLANG_VERSION),
+  V3_6_12(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_6_X_MIN_ERLANG_VERSION),
+  V3_6_11(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_6_X_MIN_ERLANG_VERSION),
+  V3_6_10(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_6_X_MIN_ERLANG_VERSION),
   V3_6_9(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_6_X_MIN_ERLANG_VERSION),
   V3_6_8(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_6_X_MIN_ERLANG_VERSION),
   V3_6_7(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_6_X_MIN_ERLANG_VERSION),
@@ -39,9 +55,12 @@ public enum PredefinedVersion implements Version {
   V3_4_1(ArchiveType.TAR_GZ, ArchiveType.ZIP, Constants.V3_4_X_MIN_ERLANG_VERSION),
   V3_4_0(ArchiveType.TAR_GZ, ArchiveType.ZIP, Constants.V3_4_X_MIN_ERLANG_VERSION),
 
-  LATEST(V3_6_9);
+  LATEST(V3_7_7);
 
   private static class Constants {
+    static final String V3_7_7_MIN_ERLANG_VERSION = "19.3.6.4";
+    static final String V3_7_X_MIN_ERLANG_VERSION = "19.3";
+    static final String V3_6_15_MIN_ERLANG_VERSION = "19.3";
     static final String V3_6_X_MIN_ERLANG_VERSION = "R16B03";
     static final String V3_5_X_MIN_ERLANG_VERSION = "R13B03";
     static final String V3_4_X_MIN_ERLANG_VERSION = null;

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/Version.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/Version.java
@@ -3,15 +3,29 @@ package io.arivera.oss.embedded.rabbitmq;
 import io.arivera.oss.embedded.rabbitmq.util.ArchiveType;
 import io.arivera.oss.embedded.rabbitmq.util.OperatingSystem;
 
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.List;
+
 /**
  * A class that provides information about a specific distribution artifact version of RabbitMQ.
  */
 public interface Version {
 
+  VersionComparator VERSION_COMPARATOR = new VersionComparator();
+
   /**
    * @return a String formatted like {@code "3.6.5"}
+   *
+   * @see #getVersionAsString(CharSequence)
    */
   String getVersionAsString();
+
+  /**
+   * @return a String formatted like {@code "3_6_5"} if given {@code "_"} as separator.
+   */
+  String getVersionAsString(CharSequence separator);
+
 
   /**
    * @return correct Archive Type for the given OS.
@@ -27,5 +41,27 @@ public interface Version {
    * @return minimum version required to run this RabbitMQ version. Example: {@code "R16B3"} or {code null}
    */
   String getMinimumErlangVersion();
+
+  /**
+   * @return an Array like [3,6,5] for version 3.6.5
+   */
+  List<Integer> getVersionComponents();
+
+  class VersionComparator implements Comparator<Version>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public int compare(Version v1, Version v2) {
+      for (int i = 0; i < v1.getVersionComponents().size(); i++) {
+        int comp = v1.getVersionComponents().get(i).compareTo(v2.getVersionComponents().get(i));
+        if (comp != 0) {
+          return comp;
+        }
+      }
+      return 0;
+    }
+
+  }
 
 }

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/helpers/ShutdownHelper.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/helpers/ShutdownHelper.java
@@ -75,7 +75,7 @@ public class ShutdownHelper implements Runnable {
           + "RabbitMQ Server to shut down", e);
     }
 
-    if (exitValue == 0 || exitValue == 143) {
+    if (exitValue == 0) {
       LOGGER.debug("RabbitMQ Server stopped successfully.");
     } else {
       LOGGER.warn("RabbitMQ Server stopped with exit value: " + exitValue);

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/helpers/ShutdownHelper.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/helpers/ShutdownHelper.java
@@ -75,7 +75,7 @@ public class ShutdownHelper implements Runnable {
           + "RabbitMQ Server to shut down", e);
     }
 
-    if (exitValue == 0) {
+    if (exitValue == 0 || exitValue == 143) {
       LOGGER.debug("RabbitMQ Server stopped successfully.");
     } else {
       LOGGER.warn("RabbitMQ Server stopped with exit value: " + exitValue);

--- a/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
+++ b/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
@@ -21,6 +21,7 @@ import org.zeroturnaround.exec.ProcessResult;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.PrintWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Map;
@@ -45,14 +46,14 @@ public class EmbeddedRabbitMqTest {
   @Test
   public void start() throws Exception {
     File configFile = temporaryFolder.newFile("rabbitmq.config");
-    FileOutputStream fileOutputStream = new FileOutputStream(configFile);
-    fileOutputStream.write("[{rabbit,[{log_levels,[{connection,debug},{channel,debug}]}]}].".getBytes("utf-8"));
-    fileOutputStream.close();
+    PrintWriter writer = new PrintWriter(configFile, "UTF-8");
+    writer.println("[{rabbit,[{log_levels,[{connection,debug},{channel,debug}]}]}].");
+    writer.close();
 
     EmbeddedRabbitMqConfig config = new EmbeddedRabbitMqConfig.Builder()
-        .version(PredefinedVersion.V3_5_7)
+        .version(PredefinedVersion.V3_6_16)
         .randomPort()
-        .downloadFrom(OfficialArtifactRepository.RABBITMQ)
+        .downloadFrom(OfficialArtifactRepository.GITHUB)
 //        .downloadFrom(new URL("https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_6_milestone1/rabbitmq-server-mac-standalone-3.6.5.901.tar.xz"), "rabbitmq_server-3.6.5.901")
 //        .envVar(RabbitMqEnvVar.NODE_PORT, String.valueOf(PORT))
         .envVar(RabbitMqEnvVar.CONFIG_FILE, configFile.toString().replace(".config", ""))

--- a/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
+++ b/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 import org.zeroturnaround.exec.ProcessResult;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -45,18 +44,19 @@ public class EmbeddedRabbitMqTest {
 
   @Test
   public void start() throws Exception {
-    File configFile = temporaryFolder.newFile("rabbitmq.config");
+    File configFile = temporaryFolder.newFile("rabbitmq.conf");
     PrintWriter writer = new PrintWriter(configFile, "UTF-8");
-    writer.println("[{rabbit,[{log_levels,[{connection,debug},{channel,debug}]}]}].");
+    writer.println("log.connection.level = debug");
+    writer.println("log.channel.level = debug");
     writer.close();
 
     EmbeddedRabbitMqConfig config = new EmbeddedRabbitMqConfig.Builder()
-        .version(PredefinedVersion.V3_6_16)
+        .version(PredefinedVersion.V3_7_3)
         .randomPort()
         .downloadFrom(OfficialArtifactRepository.GITHUB)
 //        .downloadFrom(new URL("https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_6_milestone1/rabbitmq-server-mac-standalone-3.6.5.901.tar.xz"), "rabbitmq_server-3.6.5.901")
 //        .envVar(RabbitMqEnvVar.NODE_PORT, String.valueOf(PORT))
-        .envVar(RabbitMqEnvVar.CONFIG_FILE, configFile.toString().replace(".config", ""))
+        .envVar(RabbitMqEnvVar.CONFIG_FILE, configFile.toString().replace(".conf", ""))
         .extractionFolder(temporaryFolder.newFolder("extracted"))
         .rabbitMqServerInitializationTimeoutInMillis(TimeUnit.SECONDS.toMillis(20))
         .defaultRabbitMqCtlTimeoutInMillis(TimeUnit.SECONDS.toMillis(20))

--- a/src/test/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepositoryTest.java
+++ b/src/test/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepositoryTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import java.net.URL;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 public class OfficialArtifactRepositoryTest {
@@ -17,7 +18,8 @@ public class OfficialArtifactRepositoryTest {
         .getUrl(PredefinedVersion.V3_6_5, OperatingSystem.WINDOWS);
 
     assertThat(url.toString(),
-        equalTo("http://www.rabbitmq.com/releases/rabbitmq-server/v3.6.5/rabbitmq-server-windows-3.6.5.zip"));
+        equalTo("http://www.rabbitmq.com/releases/rabbitmq-server"
+            + "/v3.6.5/rabbitmq-server-windows-3.6.5.zip"));
   }
 
   @Test
@@ -26,7 +28,8 @@ public class OfficialArtifactRepositoryTest {
         .getUrl(PredefinedVersion.V3_6_5, OperatingSystem.MAC_OS);
 
     assertThat(url.toString(),
-        equalTo("http://www.rabbitmq.com/releases/rabbitmq-server/v3.6.5/rabbitmq-server-mac-standalone-3.6.5.tar.xz"));
+        equalTo("http://www.rabbitmq.com/releases/rabbitmq-server"
+            + "/v3.6.5/rabbitmq-server-mac-standalone-3.6.5.tar.xz"));
   }
 
   @Test
@@ -35,17 +38,8 @@ public class OfficialArtifactRepositoryTest {
         .getUrl(PredefinedVersion.V3_6_5, OperatingSystem.UNIX);
 
     assertThat(url.toString(),
-        equalTo("http://www.rabbitmq.com/releases/rabbitmq-server/v3.6.5/rabbitmq-server-generic-unix-3.6.5.tar.xz"));
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void downloadTooNew() throws Exception {
-      URL url = OfficialArtifactRepository.RABBITMQ
-           .getUrl(PredefinedVersion.V3_7_0, OperatingSystem.UNIX);
-
-      assertThat(url.toString(),
-          equalTo("http://www.rabbitmq.com/releases/rabbitmq-server/"
-              + "v3.6.5/rabbitmq-server-generic-unix-3.6.5.tar.xz"));
+        equalTo("http://www.rabbitmq.com/releases/rabbitmq-server"
+            + "/v3.6.5/rabbitmq-server-generic-unix-3.6.5.tar.xz"));
   }
 
   @Test
@@ -54,8 +48,8 @@ public class OfficialArtifactRepositoryTest {
         .getUrl(PredefinedVersion.V3_6_5, OperatingSystem.MAC_OS);
 
     assertThat(url.toString(),
-        equalTo("https://github.com/rabbitmq/rabbitmq-server/releases/"
-            + "download/rabbitmq_v3_6_5/rabbitmq-server-mac-standalone-3.6.5.tar.xz"));
+        equalTo("https://github.com/rabbitmq/rabbitmq-server/releases/download"
+            + "/rabbitmq_v3_6_5/rabbitmq-server-mac-standalone-3.6.5.tar.xz"));
   }
 
   @Test
@@ -64,8 +58,18 @@ public class OfficialArtifactRepositoryTest {
           .getUrl(PredefinedVersion.V3_7_7, OperatingSystem.MAC_OS);
 
       assertThat(url.toString(),
-          equalTo("https://github.com/rabbitmq/rabbitmq-server/releases/"
-              + "download/v3.7.7/rabbitmq-server-mac-standalone-3.7.7.tar.xz"));
+          equalTo("https://github.com/rabbitmq/rabbitmq-server/releases/download"
+              + "/v3.7.7/rabbitmq-server-mac-standalone-3.7.7.tar.xz"));
+  }
+
+  @Test
+  public void githubRepoOldForUnix() throws Exception {
+    URL url = OfficialArtifactRepository.GITHUB
+        .getUrl(PredefinedVersion.V3_6_13, OperatingSystem.UNIX);
+
+    assertThat(url.toString(),
+        equalTo("https://github.com/rabbitmq/rabbitmq-server/releases/download"
+            + "/rabbitmq_v3_6_13/rabbitmq-server-generic-unix-3.6.13.tar.xz"));
   }
 
   @Test
@@ -74,8 +78,8 @@ public class OfficialArtifactRepositoryTest {
           .getUrl(PredefinedVersion.V3_7_3, OperatingSystem.UNIX);
 
       assertThat(url.toString(),
-          equalTo("https://github.com/rabbitmq/rabbitmq-server/releases/"
-              + "download/v3.7.3/rabbitmq-server-generic-unix-3.7.3.tar.xz"));
+          equalTo("https://github.com/rabbitmq/rabbitmq-server/releases/download"
+              + "/v3.7.3/rabbitmq-server-generic-unix-3.7.3.tar.xz"));
   }
 
   @Test
@@ -84,8 +88,18 @@ public class OfficialArtifactRepositoryTest {
           .getUrl(PredefinedVersion.V3_7_7, OperatingSystem.MAC_OS);
 
       assertThat(url.toString(),
-          equalTo("https://dl.bintray.com/rabbitmq/all/rabbitmq-server/"
-              + "3.7.7/rabbitmq-server-mac-standalone-3.7.7.tar.xz"));
+          equalTo("https://dl.bintray.com/rabbitmq/all/rabbitmq-server"
+              + "/3.7.7/rabbitmq-server-mac-standalone-3.7.7.tar.xz"));
   }
 
+  @Test(expected = IllegalStateException.class)
+  public void rabbitMqRepoWontGenerateUrlForVersion3_7andHigher() throws Exception {
+    OfficialArtifactRepository.RABBITMQ.getUrl(PredefinedVersion.V3_7_0, null);
+  }
+
+  @Test
+  public void rabbitMqRepoWillGenerateUrlForVersionsBelow3_7() {
+    URL url = OfficialArtifactRepository.RABBITMQ.getUrl(PredefinedVersion.V3_6_13, null);
+    assertNotNull(url);
+  }
 }

--- a/src/test/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepositoryTest.java
+++ b/src/test/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepositoryTest.java
@@ -38,14 +38,54 @@ public class OfficialArtifactRepositoryTest {
         equalTo("http://www.rabbitmq.com/releases/rabbitmq-server/v3.6.5/rabbitmq-server-generic-unix-3.6.5.tar.xz"));
   }
 
+  @Test(expected = IllegalStateException.class)
+  public void downloadTooNew() throws Exception {
+      URL url = OfficialArtifactRepository.RABBITMQ
+           .getUrl(PredefinedVersion.V3_7_0, OperatingSystem.UNIX);
+
+      assertThat(url.toString(),
+          equalTo("http://www.rabbitmq.com/releases/rabbitmq-server/"
+              + "v3.6.5/rabbitmq-server-generic-unix-3.6.5.tar.xz"));
+  }
+
   @Test
-  public void githubRepo() throws Exception {
+  public void githubRepoOldForMac() throws Exception {
     URL url = OfficialArtifactRepository.GITHUB
         .getUrl(PredefinedVersion.V3_6_5, OperatingSystem.MAC_OS);
 
     assertThat(url.toString(),
         equalTo("https://github.com/rabbitmq/rabbitmq-server/releases/"
             + "download/rabbitmq_v3_6_5/rabbitmq-server-mac-standalone-3.6.5.tar.xz"));
+  }
+
+  @Test
+  public void githubRepoNewForMac() throws Exception {
+      URL url = OfficialArtifactRepository.GITHUB
+          .getUrl(PredefinedVersion.V3_7_7, OperatingSystem.MAC_OS);
+
+      assertThat(url.toString(),
+          equalTo("https://github.com/rabbitmq/rabbitmq-server/releases/"
+              + "download/v3.7.7/rabbitmq-server-mac-standalone-3.7.7.tar.xz"));
+  }
+
+  @Test
+  public void githubRepoNewForUnix() throws Exception {
+      URL url = OfficialArtifactRepository.GITHUB
+          .getUrl(PredefinedVersion.V3_7_3, OperatingSystem.UNIX);
+
+      assertThat(url.toString(),
+          equalTo("https://github.com/rabbitmq/rabbitmq-server/releases/"
+              + "download/v3.7.3/rabbitmq-server-generic-unix-3.7.3.tar.xz"));
+  }
+
+  @Test
+  public void bintrayRepoNewForMac() throws Exception {
+      URL url = OfficialArtifactRepository.BINTRAY
+          .getUrl(PredefinedVersion.V3_7_7, OperatingSystem.MAC_OS);
+
+      assertThat(url.toString(),
+          equalTo("https://dl.bintray.com/rabbitmq/all/rabbitmq-server/"
+              + "3.7.7/rabbitmq-server-mac-standalone-3.7.7.tar.xz"));
   }
 
 }

--- a/src/test/java/io/arivera/oss/embedded/rabbitmq/PredefinedVersionTest.java
+++ b/src/test/java/io/arivera/oss/embedded/rabbitmq/PredefinedVersionTest.java
@@ -15,6 +15,14 @@ public class PredefinedVersionTest {
 
   @Test
   public void latestEnumIsNewestVersion() throws Exception {
-    assertThat(PredefinedVersion.LATEST.version, equalTo(PredefinedVersion.values()[0].getVersionAsString()));
+    PredefinedVersion firstDefinedEnumValue = PredefinedVersion.values()[0];
+    assertThat(PredefinedVersion.LATEST.getVersionAsString(), equalTo(firstDefinedEnumValue.getVersionAsString()));
+  }
+
+  @Test
+  public void testCompareTo() {
+    assertThat(Version.VERSION_COMPARATOR.compare(PredefinedVersion.V3_7_5, PredefinedVersion.V3_7_5), equalTo(0));
+    assertThat(Version.VERSION_COMPARATOR.compare(PredefinedVersion.V3_7_7, PredefinedVersion.V3_7_5), equalTo(1));
+    assertThat(Version.VERSION_COMPARATOR.compare(PredefinedVersion.V3_6_13, PredefinedVersion.V3_7_7), equalTo(-1));
   }
 }

--- a/src/test/java/io/arivera/oss/embedded/rabbitmq/helpers/ErlangVersionCheckerTest.java
+++ b/src/test/java/io/arivera/oss/embedded/rabbitmq/helpers/ErlangVersionCheckerTest.java
@@ -27,16 +27,17 @@ public class ErlangVersionCheckerTest {
 
   @Test
   public void parseR() {
-    assertThat(ErlangVersionChecker.parse("R15B03-1"), equalTo(15.0660003d));
-    assertThat(ErlangVersionChecker.parse("R15B"), equalTo(15.066d));
-    assertThat(ErlangVersionChecker.parse("R11B-5"), equalTo(11.066d));
+    assertThat(ErlangVersionChecker.parse("R15B03-1"), equalTo(new int[] {15, 66, 3, 0, 0}));
+    assertThat(ErlangVersionChecker.parse("R15B"), equalTo(new int[] {15, 66, 0, 0, 0}));
+    assertThat(ErlangVersionChecker.parse("R11B-5"), equalTo(new int[] {11, 66, 0, 0, 0}));
   }
 
   @Test
   public void parseOtp() {
-    assertThat(ErlangVersionChecker.parse("18.0"), equalTo(18.0d));
-    assertThat(ErlangVersionChecker.parse("18.2.1"), equalTo(18.0020001d));
-    assertThat(ErlangVersionChecker.parse("18.3"), equalTo(18.003d));
+    assertThat(ErlangVersionChecker.parse("18.0"), equalTo(new int[] {18, 0, 0, 0, 0}));
+    assertThat(ErlangVersionChecker.parse("18.2.1"), equalTo(new int[] {18, 2, 1, 0, 0}));
+    assertThat(ErlangVersionChecker.parse("18.3"), equalTo(new int[] {18, 3, 0, 0, 0}));
+    assertThat(ErlangVersionChecker.parse("19.3.6.4"), equalTo(new int[] {19, 3, 6, 4, 0}));
   }
 
   @Test
@@ -80,6 +81,18 @@ public class ErlangVersionCheckerTest {
     String minErlangVersion = "R14B01-3";
     ErlangVersionChecker checker = new ErlangVersionChecker(minErlangVersion, shell);
     checker.check();
+  }
+
+  @Test
+  public void versionCheckPasses2() throws ErlangShellException {
+    when(shell.getErlangVersion()).thenReturn("18.1.0");
+    new ErlangVersionChecker("18.0.1", shell).check();
+  }
+
+  @Test(expected = ErlangVersionException.class)
+  public void versionCheckFails() throws ErlangShellException {
+      when(shell.getErlangVersion()).thenReturn("21.0.1");
+      new ErlangVersionChecker("21.1.0", shell).check();
   }
 
   @Test


### PR DESCRIPTION
- Add newest versions of RabbitMQ.
- Switched default download source to GitHub as it spans more versions.
- Add support for more digits to the version comparator.
- Add bintray download source.
- Fixes #44 