### PR TITLE
Dockerizing the build to use JDK 7 + Maven 3.5.4 + Erlang 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
     - $HOME/.embeddedrabbitmq
 
 script:
+  - make image
   - make build
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
-language: java
+sudo: required
 
-rvm:
- - 2.3
-
-matrix:
-  include:
-  - os: osx           # OS X (10.9) which comes with Oracle's Java 1.7.0_45
+services:
+  - docker
 
 env:
   global:
@@ -18,18 +14,12 @@ cache:
     - $HOME/.m2/repository
     - $HOME/.embeddedrabbitmq
 
-before_install:
-  - brew update
-  - brew install erlang      # Erlang 17 will be installed without even updating brew!
-  - export JAVA_HOME="$(/usr/libexec/java_home -v 1.7)"    # Required by Maven
-  - erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
-
 script:
-  - mvn clean install
+  - make build
 
 after_success:
-  - mvn deploy -DskipTests -s maven-settings.xml
-  - mvn jacoco:report coveralls:report
+  - make deploy
+  - make report
 
 notifications:
   email:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM maven:3.5.4-jdk-7-slim
+
+# Install Erlang
+RUN apt-get update && \
+    apt-get install -y \
+      erlang \
+    && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,14 @@ build:
 			mvn install
 
 deploy:
-	docker run $(DOCKER_OPTS) $(DOCKER_IMAGE) \
+	docker run $(DOCKER_OPTS)\
 		-e SONATYPE_NEXUS_USERNAME \
 		-e SONATYPE_NEXUS_PASSWORD \
+		$(DOCKER_IMAGE) \
 			mvn deploy -DskipTests -s maven-settings.xml
 
 report:
-	docker run $(DOCKER_OPTS) $(DOCKER_IMAGE) \
+	docker run $(DOCKER_OPTS) \
 		-e COVERALLS_TOKEN \
+		$(DOCKER_IMAGE) \
 			mvn jacoco:report coveralls:report

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,17 @@ clean:
 image:
 	docker build -t $(DOCKER_IMAGE) .
 
-build: image
+build:
 	docker run $(DOCKER_OPTS) $(DOCKER_IMAGE) \
 			mvn install
 
-deploy: image
+deploy:
 	docker run $(DOCKER_OPTS) $(DOCKER_IMAGE) \
+		-e SONATYPE_NEXUS_USERNAME \
+		-e SONATYPE_NEXUS_PASSWORD \
 			mvn deploy -DskipTests -s maven-settings.xml
 
-report: image
+report:
 	docker run $(DOCKER_OPTS) $(DOCKER_IMAGE) \
+		-e COVERALLS_TOKEN \
 			mvn jacoco:report coveralls:report

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+PWD=$(shell pwd)
+DOCKER_IMAGE=my_maven
+DOCKER_OPTS=-t -v $(PWD):/app -w /app -v ~/.m2:/root/.m2 -v $(HOME)/.embeddedrabbitmq:/root/.embeddedrabbitmq
+
+.PHONY: image clean build deploy report
+
+default: build
+
+clean:
+	docker run $(DOCKER_OPTS) $(DOCKER_IMAGE) \
+			mvn clean
+
+image:
+	docker build -t $(DOCKER_IMAGE) .
+
+build: image
+	docker run $(DOCKER_OPTS) $(DOCKER_IMAGE) \
+			mvn install
+
+deploy: image
+	docker run $(DOCKER_OPTS) $(DOCKER_IMAGE) \
+			mvn deploy -DskipTests -s maven-settings.xml
+
+report: image
+	docker run $(DOCKER_OPTS) $(DOCKER_IMAGE) \
+			mvn jacoco:report coveralls:report


### PR DESCRIPTION
Travis no longer supports JDK 7!

To have a reproducible build, we now use Docker with an image that controls the installed dependencies.