### PR TITLE
With version 3.7.18, MacOS binaries are no longer provided.

### DIFF
--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepository.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepository.java
@@ -70,8 +70,7 @@ public enum OfficialArtifactRepository implements ArtifactRepository {
 
   @Override
   public URL getUrl(Version version, OperatingSystem operatingSystem) {
-
-    String artifactPlatform = downloadPlatformName.get(operatingSystem);
+    String artifactPlatform = getArtifactPlatform(version, operatingSystem);
     ArchiveType archiveType = version.getArchiveType(operatingSystem);
 
     String filenameVersion = version.getVersionAsString();
@@ -85,6 +84,25 @@ public enum OfficialArtifactRepository implements ArtifactRepository {
     } catch (MalformedURLException e) {
       throw new IllegalStateException("Download URL is invalid: " + url, e);
     }
+  }
+
+  /**
+   * RabbitMQ releases used to include a special binary package for macOS that bundled a supported version of
+   * Erlang/OTP. As of September 2019, this package has been discontinued.
+   * It will no longer be produced for new RabbitMQ releases.
+   * <p/>
+   * MacOS users should use the Homebrew formula or the generic binary build (requires a supported version of Erlang
+   * to be installed separately) to provision RabbitMQ.
+   *
+   * @see <a href="https://www.rabbitmq.com/install-standalone-mac.html">Announcement</a>
+   */
+  protected String getArtifactPlatform(Version version, OperatingSystem operatingSystem) {
+    if (operatingSystem == OperatingSystem.MAC_OS && version instanceof PredefinedVersion
+        && PredefinedVersion.V3_7_18.compareTo((PredefinedVersion) version) >= 0) {
+      // v3.7.18 was the first Sep. 2019 release
+      return downloadPlatformName.get(OperatingSystem.UNIX);
+    }
+    return downloadPlatformName.get(operatingSystem);
   }
 
   protected String getFolderVersion(Version version) {

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/PredefinedVersion.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/PredefinedVersion.java
@@ -17,6 +17,8 @@ import java.util.List;
  */
 public enum PredefinedVersion implements Version {
 
+  V3_8_0(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_8_0_MIN_ERLANG_VERSION),
+  V3_7_18(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_7_18_MIN_ERLANG_VERSION),
   V3_7_7(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_7_7_MIN_ERLANG_VERSION),
   V3_7_6(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_7_X_MIN_ERLANG_VERSION),
   V3_7_5(ArchiveType.TAR_XZ, ArchiveType.ZIP, Constants.V3_7_X_MIN_ERLANG_VERSION),
@@ -59,9 +61,11 @@ public enum PredefinedVersion implements Version {
   V3_4_1(ArchiveType.TAR_GZ, ArchiveType.ZIP, Constants.V3_4_X_MIN_ERLANG_VERSION),
   V3_4_0(ArchiveType.TAR_GZ, ArchiveType.ZIP, Constants.V3_4_X_MIN_ERLANG_VERSION),
 
-  LATEST(V3_7_7);
+  LATEST(V3_8_0);
 
   private static class Constants {
+    static final String V3_8_0_MIN_ERLANG_VERSION = "21.3";
+    static final String V3_7_18_MIN_ERLANG_VERSION = "20.3";
     static final String V3_7_7_MIN_ERLANG_VERSION = "19.3.6.4";
     static final String V3_7_X_MIN_ERLANG_VERSION = "19.3";
     static final String V3_6_15_MIN_ERLANG_VERSION = "19.3";

--- a/src/test/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepositoryTest.java
+++ b/src/test/java/io/arivera/oss/embedded/rabbitmq/OfficialArtifactRepositoryTest.java
@@ -63,6 +63,23 @@ public class OfficialArtifactRepositoryTest {
   }
 
   @Test
+  public void githubRepoNewForMacAfterV3_7_18() throws Exception {
+    URL url = OfficialArtifactRepository.GITHUB
+        .getUrl(PredefinedVersion.V3_7_18, OperatingSystem.MAC_OS);
+
+    assertThat(url.toString(),
+        equalTo("https://github.com/rabbitmq/rabbitmq-server/releases/download"
+            + "/v3.7.18/rabbitmq-server-generic-unix-3.7.18.tar.xz"));
+
+    url = OfficialArtifactRepository.GITHUB
+        .getUrl(PredefinedVersion.V3_8_0, OperatingSystem.MAC_OS);
+
+    assertThat(url.toString(),
+        equalTo("https://github.com/rabbitmq/rabbitmq-server/releases/download"
+            + "/v3.8.0/rabbitmq-server-generic-unix-3.8.0.tar.xz"));
+  }
+
+  @Test
   public void githubRepoOldForUnix() throws Exception {
     URL url = OfficialArtifactRepository.GITHUB
         .getUrl(PredefinedVersion.V3_6_13, OperatingSystem.UNIX);


### PR DESCRIPTION
Using generic Unix instead.