### PR TITLE
Update commons-compress dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
             <!-- Used to decompress TAR (+GZ) files -->
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.18</version>
+            <version>1.19</version>
         </dependency>
         <dependency>
             <!-- Used to decompress XZ files -->


### PR DESCRIPTION
Motivation:

We should use the latest commons-compress release to fix CVE-2019-12402

Modifications:

Update commons-compress to 1.19

Result:

Fix OWASP Dependency-Check security alert