### PR TITLE
Created RabbitMqDiagnostics to extend RabbitMqCtl and RabbitMqPlugins from

### DIFF
--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/bin/RabbitMqCtl.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/bin/RabbitMqCtl.java
@@ -4,39 +4,37 @@ import io.arivera.oss.embedded.rabbitmq.EmbeddedRabbitMqConfig;
 
 import org.zeroturnaround.exec.ProcessResult;
 
+import java.io.File;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Future;
 
 /**
- * This is a wrapper around {@link RabbitMqCommand} to make it easier to execute "{@value COMMAND}" commands.
+ * This is a helper class meant to facilitate invoking commands from {@code rabbitmqctl}.
  * <p>
  * The methods contained in this class aren't exhaustive. Please refer to the manual for a complete list.
  *
- * @see <a href="https://www.rabbitmq.com/man/rabbitmqctl.1.man.html">rabbitmqctl(1) manual page</a>
+ * @see <a href="https://www.rabbitmq.com/rabbitmqctl.8.html">rabbitmqctl(8) manual page</a>
  */
-public class RabbitMqCtl {
+public class RabbitMqCtl extends RabbitMqDiagnostics {
 
   public static final String COMMAND = "rabbitmqctl";
 
-  private EmbeddedRabbitMqConfig config;
-
   public RabbitMqCtl(EmbeddedRabbitMqConfig config) {
-    this.config = config;
+    super(config);
   }
 
-  /**
-   * This method exposes a way to invoke {@value COMMAND} with any arguments. This is useful when the class methods
-   * don't expose the desired functionality.
-   * <p>
-   * For example:
-   * <pre><code>
-   * RabbitMqCtl command = new RabbitMqCtl(config);
-   * command.execute("list_users");
-   * </code></pre>
-   */
-  public Future<ProcessResult> execute(String... arguments) throws RabbitMqCommandException {
-    return new RabbitMqCommand(config, COMMAND, arguments)
-        .call()
-        .getFuture();
+  public RabbitMqCtl(EmbeddedRabbitMqConfig config, Map<String, String> extraEnvVars) {
+    super(config, extraEnvVars);
+  }
+
+  public RabbitMqCtl(EmbeddedRabbitMqConfig config, Set<String> envVarsToDiscard, Map<String, String> envVarsToAdd) {
+    super(config, envVarsToDiscard, envVarsToAdd);
+  }
+
+  public RabbitMqCtl(RabbitMqCommand.ProcessExecutorFactory processExecutorFactory, File appFolder,
+                     Map<String, String> envVars) {
+    super(processExecutorFactory, appFolder, envVars);
   }
 
   /**
@@ -91,4 +89,8 @@ public class RabbitMqCtl {
     return execute("force_reset");
   }
 
+  @Override
+  protected String getCommand() {
+    return COMMAND;
+  }
 }

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/bin/RabbitMqDiagnostics.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/bin/RabbitMqDiagnostics.java
@@ -1,0 +1,103 @@
+package io.arivera.oss.embedded.rabbitmq.bin;
+
+import io.arivera.oss.embedded.rabbitmq.EmbeddedRabbitMqConfig;
+
+import org.zeroturnaround.exec.ProcessResult;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
+
+/**
+ * This is a helper class meant to facilitate invoking commands from {@code rabbitmq-diagnostics}.
+ *
+ * @see <a href="https://www.rabbitmq.com/rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8) manual page</a>
+ */
+public class RabbitMqDiagnostics {
+
+  /**
+   * Default list of Environment Variables to discard from {@link EmbeddedRabbitMqConfig#getEnvVars()}, as
+   * it is known that some of them cause conflicts when executing commands.
+   */
+  private static final Set<String> DEFAULT_ENV_VARS_TO_DISCARD = new HashSet<>(Arrays.asList("RABBITMQ_NODE_PORT"));
+  private static final String COMMAND = "rabbitmq-diagnostics";
+
+  private RabbitMqCommand.ProcessExecutorFactory peFactory;
+  private File appFolder;
+  private Map<String, String> envVars;
+
+  public RabbitMqDiagnostics(EmbeddedRabbitMqConfig config) {
+    this(config, Collections.EMPTY_MAP);
+  }
+
+  /**
+   * A constructor that allows additional env vars while also discarding default known vars that cause issues.
+   *
+   * @see #DEFAULT_ENV_VARS_TO_DISCARD
+   */
+  public RabbitMqDiagnostics(EmbeddedRabbitMqConfig config, Map<String, String> extraEnvVars) {
+    this(config, DEFAULT_ENV_VARS_TO_DISCARD, extraEnvVars);
+  }
+
+  /**
+   * A constructor that allows additional env vars while also allowing to override the default env vars to discard.
+   *
+   * @see #DEFAULT_ENV_VARS_TO_DISCARD
+   */
+  public RabbitMqDiagnostics(EmbeddedRabbitMqConfig config,
+                             Set<String> envVarsToDiscard,
+                             Map<String, String> envVarsToAdd) {
+    this(config.getProcessExecutorFactory(), config.getAppFolder(),
+        mapFilterAndAppend(config.getEnvVars(), envVarsToDiscard, envVarsToAdd));
+  }
+
+  /**
+   * Full-fledged constructor.
+   */
+  public RabbitMqDiagnostics(RabbitMqCommand.ProcessExecutorFactory processExecutorFactory,
+                             File appFolder, Map<String, String> envVars) {
+    this.peFactory = processExecutorFactory;
+    this.appFolder = appFolder;
+    this.envVars = envVars;
+  }
+
+  protected static Map<String, String> mapFilterAndAppend(Map<String, String> envVars,
+                                                          Set<String> envVarsToDiscard,
+                                                          Map<String, String> envVarsToAdd) {
+    Map<String, String> tmpEnvVars = envVars;
+    if (!envVarsToDiscard.isEmpty() || envVarsToAdd.isEmpty()) {
+      tmpEnvVars = new HashMap<>(tmpEnvVars);
+      for (String var : envVarsToDiscard) {
+        tmpEnvVars.remove(var);
+      }
+      tmpEnvVars.putAll(envVarsToAdd);
+    }
+    return tmpEnvVars;
+  }
+
+  /**
+   * This method exposes a way to invoke a command with any arguments. This is useful when the class methods
+   * don't expose the desired functionality.
+   * <p>
+   * For example:
+   * <pre><code>
+   * RabbitMqDiagnostics command = new RabbitMqDiagnostics(config);
+   * command.execute("list_users");
+   * </code></pre>
+   */
+  public Future<ProcessResult> execute(String... arguments) throws RabbitMqCommandException {
+    return new RabbitMqCommand(peFactory, envVars, appFolder, getCommand(), arguments)
+        .call()
+        .getFuture();
+  }
+
+  protected String getCommand() {
+    return COMMAND;
+  }
+
+}

--- a/src/main/java/io/arivera/oss/embedded/rabbitmq/bin/RabbitMqServer.java
+++ b/src/main/java/io/arivera/oss/embedded/rabbitmq/bin/RabbitMqServer.java
@@ -85,7 +85,6 @@ public class RabbitMqServer {
     return new RabbitMqCommand(config, COMMAND, arguments)
         .writeOutputTo(outputStream)
         .listenToEvents(listener)
-        .enableEnvVars()
         .call()
         .getFuture();
   }

--- a/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
+++ b/src/test/java/com/sample/project/EmbeddedRabbitMqTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -51,7 +52,7 @@ public class EmbeddedRabbitMqTest {
     writer.close();
 
     EmbeddedRabbitMqConfig config = new EmbeddedRabbitMqConfig.Builder()
-        .version(PredefinedVersion.V3_7_18)
+        .version(PredefinedVersion.V3_8_0)
         .randomPort()
         .downloadFrom(OfficialArtifactRepository.GITHUB)
 //        .downloadFrom(new URL("https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_6_milestone1/rabbitmq-server-mac-standalone-3.6.5.901.tar.xz"), "rabbitmq_server-3.6.5.901")
@@ -80,7 +81,7 @@ public class EmbeddedRabbitMqTest {
     Channel channel = connection.createChannel();
     assertThat(channel.isOpen(), equalTo(true));
 
-    ProcessResult listUsersResult = new RabbitMqCtl(config)
+    ProcessResult listUsersResult = new RabbitMqCtl(config, Collections.singletonMap("TEST_ENV_VAR", "FooBar"))
         .execute("list_users")
         .get();
 

--- a/src/test/java/io/arivera/oss/embedded/rabbitmq/bin/RabbitMqCommandTest.java
+++ b/src/test/java/io/arivera/oss/embedded/rabbitmq/bin/RabbitMqCommandTest.java
@@ -134,7 +134,7 @@ public class RabbitMqCommandTest {
 
     configBuilder.envVars(envVars);
 
-    rabbitMqCommand = new RabbitMqCommand(configBuilder.build(), command).enableEnvVars();
+    rabbitMqCommand = new RabbitMqCommand(configBuilder.build(), command);
     rabbitMqCommand.call();
 
     verify(processExecutor).environment(envVars);


### PR DESCRIPTION
This new class centralizes the fix for handling environment variables when executing these specific commands. Previously, *ALL* environment variables were being ignored. Now, only a specific set is ignored (from the ones RabbitMqConfig defines) -- it can be overridden -- and extra env vars can be specified.

Example:
```
    ProcessResult listUsersResult = new RabbitMqCtl(config, Collections.singletonMap("TEST_ENV_VAR", "FooBar"))
        .execute("list_users")
        .get();
```
will produce a DEBUG log like this:
```
23:34:15.012 DEBUG       main i.a.o.e.r.E.P.rabbitmqctl - Executing '/var/folders/.../extracted/rabbitmq_server-3.8.0/sbin/rabbitmqctl list_users' with environment vars: {RABBITMQ_CONFIG_FILE=/var/folders/.../rabbitmq, TEST_ENV_VAR=FooBar}
```
Notice the above env var list is missing the `RABBITMQ_NODE_PORT`, as intended. 
